### PR TITLE
Vercel is added to that Git ignore

### DIFF
--- a/packages/snfoundry/.gitignore
+++ b/packages/snfoundry/.gitignore
@@ -2,3 +2,5 @@ target
 .snfoundry_cache/
 .env
 local-devnet
+
+.vercel


### PR DESCRIPTION


# Vercel is added to that Git ignore

Fixes #Vercel is added so that Git ignores it, thus preventing unnecessary files and sensitive data from being loaded

## Types of change

- [ ] Feature
- [X ] Bug
- [ ] Enhancement

## Comments (optional)
