### PR TITLE
Implement a draws panel

### DIFF
--- a/packages/nextjs/app/admin/DrawsCard.tsx
+++ b/packages/nextjs/app/admin/DrawsCard.tsx
@@ -1,0 +1,27 @@
+import { Trophy, ArrowRight } from "lucide-react";
+import { Card, CardContent } from "~~/components/ui/card";
+import { Button } from "~~/components/ui/button";
+import Link from "next/link";
+
+export default function DrawsCard() {
+  return (
+    <Card className="bg-zinc-900 border-zinc-800 overflow-hidden hover:shadow-lg hover:shadow-purple-900/10 transition-all duration-300">
+      <CardContent className="p-6 flex flex-col items-center text-center">
+        <div className="w-16 h-16 rounded-full bg-gradient-to-br from-amber-800 to-amber-900/60 flex items-center justify-center mb-4 shadow-md">
+          <Trophy className="w-8 h-8 text-amber-400" />
+        </div>
+
+        <h3 className="text-xl font-semibold text-white mb-1">Draws</h3>
+
+        <p className="text-zinc-400 mb-6">Manage draws and results</p>
+
+        <Link href="/admin/draws">
+          <Button className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-5 rounded-md transition-all duration-200 flex items-center gap-2 hover:gap-3">
+            Go to Draws
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import StatisticsCard from "./statisticsCard";
 import Header from "~~/components/admin/Header";
 import SettingsCard from "~~/components/admin-panel/SettingsCard";
+import DrawsCard from "./DrawsCard";
 
 export default function AdminPage() {
   const { openModal } = useSweepstakesStore();
@@ -24,6 +25,7 @@ export default function AdminPage() {
       {/* Grid de tarjetas (llama las tarjetas) */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <StatisticsCard />
+        <DrawsCard />
       </div>
     </div>
   );


### PR DESCRIPTION
### Pull Request: Implement A Draws Panel

## 📌 Description

Added a new DrawsCard component to the admin panel that allows users to navigate to the Draws management section. The card displays a trophy icon, title, description, and a navigation button.

## 🎯 Motivation and Context

This change implements the requested Draws Panel (Sorteos) feature for the admin dashboard. It provides users with an intuitive way to access and manage draws and results.


## 🛠️ How to Test the Change (if applicable)

Describe the steps to test your changes:

1. 🔹 Navigate to the admin dashboard
2. 🔹 Verify the Draws card appears with the trophy icon, title, and description
3. 🔹 Click the "Go to Draws" button and confirm it navigates to the draws management page


## 🖼️ Screenshots (if applicable)
![Screenshot 2025-04-22 195105](https://github.com/user-attachments/assets/fee2a291-0195-496d-95c5-c7947478adc1)


## 🔍 Type of Change

- ✨ **New Feature** - Adds a new feature or functionality.


## ✅ Checklist Before Merging

- 🧪 I have tested the code and it works as expected.
- 🎨 My changes follow the project's coding style.
- ⚠️ No new warnings or errors were introduced.
- 🔍 I have reviewed and approved my own code before submitting.

Closes #105 