### PR TITLE
Token type validation

### DIFF
--- a/packages/snfoundry/contracts/src/StarkPlayERC20.cairo
+++ b/packages/snfoundry/contracts/src/StarkPlayERC20.cairo
@@ -7,6 +7,7 @@ pub const INITIAL_SUPPLY: u256 = 0; // initial supply
 const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
 const BURNER_ROLE: felt252 = selector!("BURNER_ROLE");
 const PAUSER_ROLE: felt252 = selector!("PAUSER_ROLE");
+const PRIZE_ASSIGNER_ROLE: felt252 = selector!("PRIZE_ASSIGNER_ROLE");
 
 #[starknet::interface]
 pub trait IMintable<TContractState> {
@@ -29,6 +30,14 @@ pub trait IBurnable<TContractState> {
     fn get_authorized_burners(self: @TContractState) -> Array<ContractAddress>;
 }
 
+#[starknet::interface]
+pub trait IPrizeToken<TContractState> {
+    fn assign_prize_tokens(ref self: TContractState, recipient: ContractAddress, amount: u256);
+    fn get_prize_balance(self: @TContractState, account: ContractAddress) -> u256;
+    fn grant_prize_assigner_role(ref self: TContractState, assigner: ContractAddress);
+    fn revoke_prize_assigner_role(ref self: TContractState, assigner: ContractAddress);
+}
+
 #[starknet::contract]
 pub mod StarkPlayERC20 {
     use openzeppelin_access::accesscontrol::AccessControlComponent;
@@ -41,7 +50,10 @@ pub mod StarkPlayERC20 {
     use openzeppelin_upgrades::interface::IUpgradeable;
     use starknet::storage::{Map, StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ClassHash, ContractAddress, get_caller_address};
-    use super::{BURNER_ROLE, IBurnable, IMintable, MINTER_ROLE, PAUSER_ROLE};
+    use super::{
+        BURNER_ROLE, IBurnable, IMintable, IPrizeToken, MINTER_ROLE, PAUSER_ROLE,
+        PRIZE_ASSIGNER_ROLE,
+    };
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
     component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
@@ -56,7 +68,6 @@ pub mod StarkPlayERC20 {
     #[abi(embed_v0)]
     impl AccessControlMixinImpl =
         AccessControlComponent::AccessControlMixinImpl<ContractState>;
-
 
     impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
     impl PausableInternalImpl = PausableComponent::InternalImpl<ContractState>;
@@ -83,6 +94,10 @@ pub mod StarkPlayERC20 {
         burners_count: u256,
         minter_index: Map<ContractAddress, u256>,
         burner_index: Map<ContractAddress, u256>,
+        prize_balances: Map<ContractAddress, u256>,
+        prize_assigners: Map<u256, ContractAddress>,
+        prize_assigners_count: u256,
+        prize_assigner_index: Map<ContractAddress, u256>,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -117,6 +132,14 @@ pub mod StarkPlayERC20 {
         pub allowance: u256,
     }
 
+    #[derive(Drop, starknet::Event)]
+    pub struct PrizeTokensAssigned {
+        #[key]
+        pub recipient: ContractAddress,
+        #[key]
+        pub amount: u256,
+    }
+
     #[event]
     #[derive(Drop, starknet::Event)]
     pub enum Event {
@@ -134,6 +157,7 @@ pub mod StarkPlayERC20 {
         Mint: Mint,
         MinterAllowanceSet: MinterAllowanceSet,
         BurnerAllowanceSet: BurnerAllowanceSet,
+        PrizeTokensAssigned: PrizeTokensAssigned,
     }
 
     #[constructor]
@@ -210,12 +234,17 @@ pub mod StarkPlayERC20 {
     impl BurnableImpl of IBurnable<ContractState> {
         fn burn(ref self: ContractState, amount: u256) {
             self.pausable.assert_not_paused();
-
             let burner = get_caller_address();
             self.accesscontrol.assert_only_role(BURNER_ROLE);
             let allowance = self.burner_allowance.read(burner);
             assert(allowance >= amount, 'Insufficient burner allowance');
             self.burner_allowance.write(burner, allowance - amount);
+            let prize_balance = self.prize_balances.read(burner);
+            if prize_balance >= amount {
+                self.prize_balances.write(burner, prize_balance - amount);
+            } else {
+                self.prize_balances.write(burner, 0);
+            }
             self.erc20.burn(burner, amount);
             self.emit(Burn { burner, amount });
         }
@@ -226,6 +255,12 @@ pub mod StarkPlayERC20 {
             let allowance = self.burner_allowance.read(caller);
             assert(allowance >= amount, 'Insufficient burner allowance');
             self.burner_allowance.write(caller, allowance - amount);
+            let prize_balance = self.prize_balances.read(account);
+            if prize_balance >= amount {
+                self.prize_balances.write(account, prize_balance - amount);
+            } else {
+                self.prize_balances.write(account, 0);
+            }
             self.erc20.burn(account, amount);
             self.emit(Burn { burner: account, amount });
         }
@@ -274,6 +309,47 @@ pub mod StarkPlayERC20 {
                 i += 1;
             };
             burners
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl PrizeTokenImpl of IPrizeToken<ContractState> {
+        fn assign_prize_tokens(ref self: ContractState, recipient: ContractAddress, amount: u256) {
+            self.pausable.assert_not_paused();
+            self.accesscontrol.assert_only_role(PRIZE_ASSIGNER_ROLE);
+            let current_prize_balance = self.prize_balances.read(recipient);
+            self.prize_balances.write(recipient, current_prize_balance + amount);
+            self.erc20.mint(recipient, amount);
+            self.emit(PrizeTokensAssigned { recipient, amount });
+        }
+
+        fn get_prize_balance(self: @ContractState, account: ContractAddress) -> u256 {
+            self.prize_balances.read(account)
+        }
+
+        fn grant_prize_assigner_role(ref self: ContractState, assigner: ContractAddress) {
+            self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
+            assert(is_contract(assigner), 'Assigner must be a contract');
+            self.accesscontrol._grant_role(PRIZE_ASSIGNER_ROLE, assigner);
+            let index = self.prize_assigners_count.read();
+            self.prize_assigners.write(index, assigner);
+            self.prize_assigner_index.write(assigner, index);
+            self.prize_assigners_count.write(index + 1);
+        }
+
+        fn revoke_prize_assigner_role(ref self: ContractState, assigner: ContractAddress) {
+            self.accesscontrol.assert_only_role(DEFAULT_ADMIN_ROLE);
+            self.accesscontrol._revoke_role(PRIZE_ASSIGNER_ROLE, assigner);
+            let index = self.prize_assigner_index.read(assigner);
+            let last_index = self.prize_assigners_count.read() - 1;
+            if index != last_index {
+                let last_assigner = self.prize_assigners.read(last_index);
+                self.prize_assigners.write(index, last_assigner);
+                self.prize_assigner_index.write(last_assigner, index);
+            }
+            self.prize_assigners.write(last_index, zero_address_const());
+            self.prize_assigner_index.write(assigner, 0);
+            self.prize_assigners_count.write(last_index);
         }
     }
 


### PR DESCRIPTION
**ISSUE-BC-CONV-005: Token Type Validation for Conversion**. The PR covers the modifications to both the `StarkPlayERC20` and `StarkPlayVault` contracts.

## 📌 Description 
This PR implements a token type validation mechanism for the `StarkPlayERC20` and `StarkPlayVault` contracts to differentiate between normal tokens (purchased by users) and prize tokens (earned via lottery). The changes include:
- Added a `prize_balances` mapping in `StarkPlayERC20` to track prize token balances.
- Implemented `assign_prize_tokens` and `get_prize_balance` functions in `StarkPlayERC20` for managing and querying prize tokens.
- Added a `convert_to_strk` function in `StarkPlayVault` to allow conversion of prize tokens to STRK, with checks for sufficient prize token balance.
- Updated storage variables `totalStarkPlayBurned` and `totalSTRKStored` in `StarkPlayVault` during conversion and emitted `StarkPlayBurned` and `ConvertedToSTRK` events.

These changes ensure that only prize tokens can be converted to STRK, aligning with the project's business model.

## 🎯 Motivation and Context 
The change is necessary to enforce the business model where normal tokens are used exclusively for purchasing lottery tickets, and only prize tokens can be converted to STRK. This prevents users from converting purchased tokens directly to STRK, maintaining the intended token flow and incentivizing participation in the lottery system. The implementation solves the problem of token differentiation and controlled conversion as outlined in ISSUE-BC-CONV-005.

Closes #154 

## 🛠️ How to Test the Change
1. 🔹 **Deploy Contracts**:
   - Deploy `StarkPlayERC20` and `StarkPlayVault` contracts.
   - Grant `PRIZE_ASSIGNER_ROLE` to a lottery contract and `BURNER_ROLE` to `StarkPlayVault` in `StarkPlayERC20`.
2. 🔹 **Test Prize Token Assignment**:
   - Call `assign_prize_tokens` from an authorized contract to assign prize tokens to a user.
   - Verify `prize_balances` is updated and `PrizeTokensAssigned` event is emitted using `get_prize_balance`.
3. 🔹 **Test Conversion**:
   - Call `convert_to_strk` with a user who has sufficient prize tokens.
   - Verify:
     - Prize tokens are burned (`prize_balances` decreases in `StarkPlayERC20`).
     - STRK is transferred to the user.
     - `totalStarkPlayBurned` increases and `totalSTRKStored` decreases in `StarkPlayVault`.
     - `StarkPlayBurned` and `ConvertedToSTRK` events are emitted.
   - Attempt conversion with insufficient prize tokens and verify it reverts with "Insufficient prize tokens".
4. 🔹 **Test Normal Tokens**:
   - Mint normal tokens via `buySTRKP` and attempt `convert_to_strk`.
   - Verify it reverts if `prize_balances` is insufficient.


## 🔍 Type of Change
- [x] ✨ **New Feature** - Adds a new feature or functionality.

## ✅ Checklist Before Merging
- [ ] 🧪 I have tested the code and it works as expected.
- [x] 🎨 My changes follow the project's coding style.
- [x] 📖 I have updated the documentation if necessary.
- [x] ⚠️ No new warnings or errors were introduced.
- [x] 🔍 I have reviewed and approved my own code before submitting.

## 📌 Additional Notes 
- Ensure the `StarkPlayVault` contract has sufficient STRK balance for conversions during testing.
- The `PRIZE_ASSIGNER_ROLE` should be granted to the lottery contract to enable prize token assignment.
- The implementation maintains ERC20 compatibility for `StarkPlayERC20`, ensuring wallet and explorer support.
- Commit message: `feat: Token Type Validation for Conversion`.
- Branch: `feature/token-type-validation-for-conversion`.

 

### Notes
- The PR description strictly reflects the changes made to address ISSUE-BC-CONV-005, including the updates to storage variables and event emissions in `StarkPlayVault`.
- The testing steps are concise and focus on verifying the core functionality of token differentiation and conversion.
- No screenshots are included, as the changes are backend smart contract modifications without a visual component.
- The artifact uses a new `artifact_id` since it’s a distinct PR description, unrelated to the previous contract artifacts.

If you need adjustments to the PR description or additional details (e.g., specific test scripts or deployment instructions), let me know!
