### PR TITLE
Feat: Implement Function to Query User's Full NFT Ticket Information

### DIFF
--- a/packages/snfoundry/contracts/src/Lottery.cairo
+++ b/packages/snfoundry/contracts/src/Lottery.cairo
@@ -61,9 +61,12 @@ trait ILottery<TContractState> {
     fn GetAccumulatedPrize(self: @TContractState) -> u256;
     fn GetFixedPrize(self: @TContractState, matches: u8) -> u256;
     fn GetDrawStatus(self: @TContractState, drawId: u64) -> bool;
-    fn GetUserTickets(
+    fn GetUserTicketIds(
         self: @TContractState, drawId: u64, player: ContractAddress,
     ) -> Array<felt252>;
+    fn GetUserTickets(
+        ref self: TContractState, drawId: u64, player: ContractAddress,
+    ) -> Array<Ticket>;
     fn GetUserTicketsCount(self: @TContractState, drawId: u64, player: ContractAddress) -> u32;
     fn GetTicketInfo(
         self: @TContractState, drawId: u64, ticketId: felt252, player: ContractAddress,
@@ -88,7 +91,6 @@ mod Lottery {
     };
     use starknet::{
         ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
-        get_contract_address,
     };
     use super::{Draw, ILottery, Ticket};
 
@@ -119,6 +121,7 @@ mod Lottery {
         TicketPurchased: TicketPurchased,
         DrawCompleted: DrawCompleted,
         PrizeClaimed: PrizeClaimed,
+        UserTicketsInfo: UserTicketsInfo,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -148,6 +151,14 @@ mod Lottery {
         player: ContractAddress,
         ticketId: felt252,
         prizeAmount: u256,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct UserTicketsInfo {
+        #[key]
+        player: ContractAddress,
+        drawId: u64,
+        tickets: Array<Ticket>,
     }
 
     //=======================================================================================
@@ -375,7 +386,7 @@ mod Lottery {
             let mut matches: u8 = 0;
 
             // Para cada número del ticket
-            let mut i: usize = 0;
+            let mut _i: usize = 0;
             if number1 == winningNumber1 {
                 matches += 1;
             }
@@ -442,23 +453,39 @@ mod Lottery {
         }
 
         //=======================================================================================
-        fn GetUserTickets(
+        fn GetUserTicketIds(
             self: @ContractState, drawId: u64, player: ContractAddress,
         ) -> Array<felt252> {
-            let mut userTickets = ArrayTrait::new();
+            let mut userTicket_ids = ArrayTrait::new();
             let count = self.userTicketCount.entry((player, drawId)).read();
 
             let mut i: u32 = 1;
-            loop {
-                if i > count {
-                    break;
-                }
+            while i != count {
                 let ticketId = self.userTicketIds.entry((player, drawId, i)).read();
-                userTickets.append(ticketId);
+                userTicket_ids.append(ticketId);
                 i += 1;
             }
 
-            userTickets
+            userTicket_ids
+        }
+
+        //=======================================================================================
+        fn GetUserTickets(
+            ref self: ContractState, drawId: u64, player: ContractAddress,
+        ) -> Array<Ticket> {
+            let ticket_ids = self.GetUserTicketIds(drawId, player);
+            let mut user_tickets_data = ArrayTrait::new();
+            let mut i: usize = 0;
+            while i != ticket_ids.len() {
+                let ticket_id = *ticket_ids.at(i);
+                let ticket_info = self.tickets.entry((drawId, ticket_id)).read();
+                assert(ticket_info.player == player, 'Ticket not owned by player');
+                user_tickets_data.append(ticket_info);
+                i += 1;
+            };
+
+            self.emit(UserTicketsInfo { player, drawId, tickets: user_tickets_data.clone() });
+            user_tickets_data
         }
 
         //=======================================================================================
@@ -559,10 +586,7 @@ mod Lottery {
         let mut count = 0;
         let mut usedNumbers: Felt252Dict<bool> = Default::default();
 
-        loop {
-            if count >= 5 {
-                break;
-            }
+        while count != 5{
             let number = (blockTimestamp + count) % (MaxNumber.into() + 1);
             let number_u16: u16 = number.try_into().unwrap();
 

--- a/packages/snfoundry/contracts/src/Lottery.cairo
+++ b/packages/snfoundry/contracts/src/Lottery.cairo
@@ -482,7 +482,7 @@ mod Lottery {
                 assert(ticket_info.player == player, 'Ticket not owned by player');
                 user_tickets_data.append(ticket_info);
                 i += 1;
-            };
+            }
 
             self.emit(UserTicketsInfo { player, drawId, tickets: user_tickets_data.clone() });
             user_tickets_data
@@ -586,7 +586,7 @@ mod Lottery {
         let mut count = 0;
         let mut usedNumbers: Felt252Dict<bool> = Default::default();
 
-        while count != 5{
+        while count != 5 {
             let number = (blockTimestamp + count) % (MaxNumber.into() + 1);
             let number_u16: u16 = number.try_into().unwrap();
 


### PR DESCRIPTION
## 📌 Description
This pull request introduces a new function `GetUserTickets` to the `Lottery` smart contract. This function allows users or front-end applications to retrieve an array containing the full data for all tickets owned by a specific player for a given draw.

Additionally, the existing function that returned only ticket IDs has been renamed from `GetUserTickets` to `GetUserTicketIds` for better clarity. A new event, `UserTicketsInfo`, is now emitted by the `GetUserTickets` function, including the player's address, the draw ID, and the complete list of their tickets. This event is designed to simplify data indexing for off-chain services.

## 🎯 Motivation and Context
The primary motivation for this change is to provide a more comprehensive way for users and applications to query ticket information. Previously, only ticket IDs could be retrieved in a batch, requiring subsequent individual calls to get full ticket details. This new function and event streamline the process of fetching all relevant ticket data for a user in a single call, improving efficiency and user experience.

This change directly addresses the requirements of [ISSUE-BC-VIS-001], which called for a function to query a user's complete NFT ticket information and emit an event for easier front-end indexing.

Closes #201 

## 🛠️ How to Test the Change (if applicable)
1.  🔹 **Deploy the Contract**: Deploy the updated `Lottery.cairo` contract to a StarkNet test environment (e.g., devnet, testnet).
2.  🔹 **Buy Tickets**: Interact with the `BuyTicket` function to purchase one or more tickets for a specific `drawId` with a test account.
3.  🔹 **Call `GetUserTickets`**:
    *   Call the new `GetUserTickets` function, providing the `drawId` and the `player` address used to buy tickets.
    *   Verify that the function returns an array of `Ticket` structs, and that the data within each struct (player, numbers, claimed status, drawId) is correct.
    *   Test with a player address that has no tickets for a specific draw to ensure an empty array is returned.
    *   Test with a player address that has multiple tickets for a draw.
4.  🔹 **Check Emitted Event**:
    *   Using a StarkNet event listener or explorer, verify that the `UserTicketsInfo` event was emitted after calling `GetUserTickets`.
    *   Confirm the event data includes the correct `player` address, `drawId`, and the `tickets` array matching the returned data.

## 🖼️ Screenshots (if applicable)
N/A

## 🔍 Type of Change
- [ ] 🐞 **Bugfix** - Fixes an existing issue or bug in the code.
- [x] ✨ **New Feature** - Adds a new feature or functionality.
- [ ] 🚀 **Hotfix** - A quick fix for a critical issue in production.
- [ ] 🔄 **Refactoring** - Improves the code structure without changing its behavior.
- [ ] 📖 **Documentation** - Updates or creates new documentation.
- [ ] ❓ **Other (please specify)** - Any other change that does not fit into the categories above.

## ✅ Checklist Before Merging
- [ ] 🧪 I have tested the code and it works as expected.
- [ ] 🎨 My changes follow the project's coding style.
- [ ] 📖 I have updated the documentation if necessary.
- [ ] ⚠️ No new warnings or errors were introduced.
- [ ] 🔍 I have reviewed and approved my own code before submitting.

## 📌 Additional Notes
*   The `GetUserTickets` function emits an event (`UserTicketsInfo`) and therefore modifies the state (by writing to the event log). Consequently, it is an external function (`ref self: ContractState`) and not a `view` function (`self: @ContractState`).
*   The `Ticket` struct includes fields like `player`, `number1`...`number5`, `claimed`, and `drawId`.
*   The implementation ensures that only tickets belonging to the specified player for the given draw are returned.