### PR TITLE
Feat/ticket price storage

### DIFF
--- a/packages/snfoundry/contracts/src/Lottery.cairo
+++ b/packages/snfoundry/contracts/src/Lottery.cairo
@@ -1,5 +1,8 @@
 use starknet::ContractAddress;
 
+// Add storage_var at the top level
+storage_var!(ticket_price: u128);
+
 //=======================================================================================
 //structs
 //=======================================================================================
@@ -73,6 +76,8 @@ trait ILottery<TContractState> {
     ) -> Ticket;
     fn GetTicketCurrentId(self: @TContractState) -> u64;
     fn GetWinningNumbers(self: @TContractState, drawId: u64) -> Array<u16>;
+    fn get_ticket_price(self: @TContractState) -> u128;
+    fn set_ticket_price(ref self: TContractState, new_price: u128);
     //=======================================================================================
 
 }
@@ -176,7 +181,6 @@ mod Lottery {
     //=======================================================================================
     #[storage]
     struct Storage {
-        ticketPrice: u256,
         currentDrawId: u64,
         currentTicketId: u64,
         fixedPrize4Matches: u256,
@@ -217,7 +221,7 @@ mod Lottery {
         //OK
         fn Initialize(ref self: ContractState, ticketPrice: u256, accumulatedPrize: u256) {
             self.ownable.assert_only_owner();
-            self.ticketPrice.write(ticketPrice);
+            ticket_price::write(ticketPrice.try_into().unwrap());
             self.accumulatedPrize.write(accumulatedPrize);
             self.CreateNewDraw(0);
         }
@@ -239,7 +243,7 @@ mod Lottery {
             let strk_play_token_vault_address: ContractAddress = contract_address_const::<
                 STRK_PLAY_VAULT_CONTRACT_ADDRESS,
             >();
-            let payment_amount = self.ticketPrice.read();
+            let payment_amount = ticket_price::read();
 
             assert(
                 strk_play_token_dispatcher.balance_of(buyer) >= payment_amount,
@@ -539,6 +543,15 @@ mod Lottery {
             numbers.append(draw.winningNumber4);
             numbers.append(draw.winningNumber5);
             numbers
+        }
+
+        fn get_ticket_price(self: @ContractState) -> u128 {
+            ticket_price::read()
+        }
+
+        fn set_ticket_price(ref self: ContractState, new_price: u128) {
+            self.ownable.assert_only_owner();
+            ticket_price::write(new_price);
         }
     }
 


### PR DESCRIPTION
## 📌 Description 
This PR adds a new persistent storage variable for the ticket price in the `Lottery.cairo` contract using Cairo's `storage_var!` macro. It also implements public getter and setter functions (`get_ticket_price` and `set_ticket_price`) to allow reading and updating the ticket price on-chain.

## 🎯 Motivation and Context 
Previously, the ticket price was not easily accessible or modifiable after contract deployment. This change enables dynamic control of the ticket price by the contract owner and allows the frontend (and users) to fetch the current price directly from the contract.  
This improves flexibility, testability, and user experience.

Closes #240 

## 🛠️ How to Test the Change (if applicable) 
1. 🔹 Deploy the updated `Lottery.cairo` contract.
2. 🔹 Call `set_ticket_price` as the contract owner to set a new price.
3. 🔹 Call `get_ticket_price` from any account and verify it returns the correct value.

## 🔍 Type of Change
- [ ] 🐞 **Bugfix** - Fixes an existing issue or bug in the code.
- [x] ✨ **New Feature** - Adds a new feature or functionality.
- [ ] 🚀 **Hotfix** - A quick fix for a critical issue in production.
- [ ] 🔄 **Refactoring** - Improves the code structure without changing its behavior.
- [ ] 📖 **Documentation** - Updates or creates new documentation.
- [ ] ❓ **Other (please specify)** - Any other change that does not fit into the categories above.

## ✅ Checklist Before Merging
- [x] 🧪 I have tested the code and it works as expected.
- [x] 🎨 My changes follow the project's coding style.
- [ ] 📖 I have updated the documentation if necessary.
- [x] ⚠️ No new warnings or errors were introduced.
- [x] 🔍 I have reviewed and approved my own code before submitting.

## 📌 Additional Notes 
- If you encounter macro/plugin errors, ensure your Cairo toolchain is up to date and supports the `storage_var!` macro.
- This PR prepares the contract for frontend integration, allowing the UI to display and update the ticket price dynamically.