### PR TITLE
Buy-ticket-by-quantity

### DIFF
--- a/packages/snfoundry/contracts/tests/test_CU01.cairo
+++ b/packages/snfoundry/contracts/tests/test_CU01.cairo
@@ -102,9 +102,7 @@ fn deploy_mock_strk_token() -> IMintableDispatcher {
     // Grant MINTER_ROLE to OWNER so we can mint tokens
     strk_token.grant_minter_role(owner_address());
     strk_token
-        .set_minter_allowance(
-            owner_address(), EXCEEDS_MINT_LIMIT().into() * 10,
-        ); // Large allowance
+        .set_minter_allowance(owner_address(), EXCEEDS_MINT_LIMIT().into() * 10); // Large allowance
 
     strk_token.mint(USER1(), EXCEEDS_MINT_LIMIT().into() * 3); // Mint plenty for testing
 

--- a/packages/snfoundry/contracts/tests/test_CU03.cairo
+++ b/packages/snfoundry/contracts/tests/test_CU03.cairo
@@ -248,7 +248,7 @@ fn test_buy_ticket_valid_numbers() {
     assert(*invalid_numbers.at(0) == 0_u16, 'First number is 0 (invalid)');
     assert(*invalid_numbers.at(2) <= 40_u16, 'Third number <= 40');
 
-    lottery_dispatcher.BuyTicket(1_u64, invalid_numbers);
+    lottery_dispatcher.BuyTicket(1_u64, invalid_numbers, 1);
 }
 
 #[should_panic(expected: 'Invalid numbers')]
@@ -260,7 +260,7 @@ fn test_buy_ticket_number_zero() {
     let invalid_numbers = array![0_u16, 10_u16, 20_u16, 30_u16, 40_u16];
 
     // This should panic because 0 is below the minimum (1)
-    lottery_dispatcher.BuyTicket(1_u64, invalid_numbers);
+    lottery_dispatcher.BuyTicket(1_u64, invalid_numbers, 1);
 }
 
 #[should_panic(expected: 'Invalid numbers')]
@@ -272,5 +272,5 @@ fn test_buy_ticket_number_above_max() {
     let invalid_numbers = array![1_u16, 10_u16, 20_u16, 30_u16, 41_u16];
 
     // This should panic because 41 is above the maximum (40)
-    lottery_dispatcher.BuyTicket(1_u64, invalid_numbers);
+    lottery_dispatcher.BuyTicket(1_u64, invalid_numbers, 1);
 }

--- a/packages/snfoundry/contracts/tests/test_starkplay_vault.cairo
+++ b/packages/snfoundry/contracts/tests/test_starkplay_vault.cairo
@@ -651,9 +651,7 @@ fn test_withdraw_general_fees_insufficient_vault_balance() {
 
     store(
         vault.contract_address, // storage owner
-        selector!(
-            "accumulatedFee",
-        ), // field marking the start of the memory chunk being written to
+        selector!("accumulatedFee"), // field marking the start of the memory chunk being written to
         array![5000].span() // array of felts to write
     );
 

--- a/packages/snfoundry/contracts/tests/ticket_price_test.cairo
+++ b/packages/snfoundry/contracts/tests/ticket_price_test.cairo
@@ -1,7 +1,10 @@
 use contracts::Lottery::{ILotteryDispatcher, ILotteryDispatcherTrait};
 use contracts::StarkPlayERC20::{IMintableDispatcher, IMintableDispatcherTrait};
 use contracts::StarkPlayVault::{IStarkPlayVaultDispatcher, IStarkPlayVaultDispatcherTrait};
-use snforge_std::{ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address, stop_cheat_caller_address};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
+    stop_cheat_caller_address,
+};
 use starknet::ContractAddress;
 
 fn OWNER() -> ContractAddress {
@@ -56,7 +59,7 @@ fn deploy_lottery() -> ContractAddress {
 fn test_initial_ticket_price() {
     let lottery_addr = deploy_lottery();
     let lottery_dispatcher = ILotteryDispatcher { contract_address: lottery_addr };
-    
+
     let initial_price = lottery_dispatcher.GetTicketPrice();
     assert!(initial_price == 0, "Initial ticket price should be 0");
 }
@@ -65,15 +68,15 @@ fn test_initial_ticket_price() {
 fn test_set_ticket_price_by_owner() {
     let lottery_addr = deploy_lottery();
     let lottery_dispatcher = ILotteryDispatcher { contract_address: lottery_addr };
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, OWNER());
-    
+
     let new_price: u256 = 1000000000000000000;
     lottery_dispatcher.SetTicketPrice(new_price);
-    
+
     let current_price = lottery_dispatcher.GetTicketPrice();
     assert!(current_price == new_price, "Ticket price was not set correctly");
-    
+
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
 }
 
@@ -81,21 +84,25 @@ fn test_set_ticket_price_by_owner() {
 fn test_set_ticket_price_multiple_times() {
     let lottery_addr = deploy_lottery();
     let lottery_dispatcher = ILotteryDispatcher { contract_address: lottery_addr };
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, OWNER());
-    
+
     let initial_price: u256 = 1000000000000000000;
     lottery_dispatcher.SetTicketPrice(initial_price);
-    assert!(lottery_dispatcher.GetTicketPrice() == initial_price, "Initial price not set correctly");
-    
+    assert!(
+        lottery_dispatcher.GetTicketPrice() == initial_price, "Initial price not set correctly",
+    );
+
     let updated_price: u256 = 2000000000000000000;
     lottery_dispatcher.SetTicketPrice(updated_price);
-    assert!(lottery_dispatcher.GetTicketPrice() == updated_price, "Updated price not set correctly");
-    
+    assert!(
+        lottery_dispatcher.GetTicketPrice() == updated_price, "Updated price not set correctly",
+    );
+
     let final_price: u256 = 500000000000000000;
     lottery_dispatcher.SetTicketPrice(final_price);
     assert!(lottery_dispatcher.GetTicketPrice() == final_price, "Final price not set correctly");
-    
+
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
 }
 
@@ -103,12 +110,12 @@ fn test_set_ticket_price_multiple_times() {
 fn test_set_ticket_price_to_zero() {
     let lottery_addr = deploy_lottery();
     let lottery_dispatcher = ILotteryDispatcher { contract_address: lottery_addr };
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, OWNER());
-    
+
     lottery_dispatcher.SetTicketPrice(0);
     assert!(lottery_dispatcher.GetTicketPrice() == 0, "Zero price not set correctly");
-    
+
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
 }
 
@@ -116,13 +123,13 @@ fn test_set_ticket_price_to_zero() {
 fn test_set_ticket_price_very_high_value() {
     let lottery_addr = deploy_lottery();
     let lottery_dispatcher = ILotteryDispatcher { contract_address: lottery_addr };
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, OWNER());
-    
+
     let high_price: u256 = 1000000000000000000000000000;
     lottery_dispatcher.SetTicketPrice(high_price);
     assert!(lottery_dispatcher.GetTicketPrice() == high_price, "High price not set correctly");
-    
+
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
 }
 
@@ -130,17 +137,17 @@ fn test_set_ticket_price_very_high_value() {
 fn test_get_ticket_price_public_access() {
     let lottery_addr = deploy_lottery();
     let lottery_dispatcher = ILotteryDispatcher { contract_address: lottery_addr };
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, OWNER());
     let set_price: u256 = 1500000000000000000;
     lottery_dispatcher.SetTicketPrice(set_price);
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, USER());
     let read_price = lottery_dispatcher.GetTicketPrice();
     assert!(read_price == set_price, "User cannot read ticket price correctly");
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, ADMIN());
     let read_price_2 = lottery_dispatcher.GetTicketPrice();
     assert!(read_price_2 == set_price, "Admin cannot read ticket price correctly");
@@ -151,18 +158,23 @@ fn test_get_ticket_price_public_access() {
 fn test_ticket_price_persistence() {
     let lottery_addr = deploy_lottery();
     let lottery_dispatcher = ILotteryDispatcher { contract_address: lottery_addr };
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, OWNER());
-    
+
     let initial_price: u256 = 1000000000000000000;
     lottery_dispatcher.SetTicketPrice(initial_price);
-    
-    assert!(lottery_dispatcher.GetTicketPrice() == initial_price, "Price not persisted after setting");
-    
+
+    assert!(
+        lottery_dispatcher.GetTicketPrice() == initial_price, "Price not persisted after setting",
+    );
+
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
     start_cheat_caller_address(lottery_dispatcher.contract_address, USER());
-    assert!(lottery_dispatcher.GetTicketPrice() == initial_price, "Price not persisted after caller change");
-    
+    assert!(
+        lottery_dispatcher.GetTicketPrice() == initial_price,
+        "Price not persisted after caller change",
+    );
+
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
 }
 
@@ -170,19 +182,24 @@ fn test_ticket_price_persistence() {
 fn test_ticket_price_with_initialize() {
     let lottery_addr = deploy_lottery();
     let lottery_dispatcher = ILotteryDispatcher { contract_address: lottery_addr };
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, OWNER());
-    
+
     let init_price: u256 = 500000000000000000;
     let accumulated_prize: u256 = 10000000000000000000;
     lottery_dispatcher.Initialize(init_price, accumulated_prize);
-    
-    assert!(lottery_dispatcher.GetTicketPrice() == init_price, "Ticket price not set during initialization");
-    
+
+    assert!(
+        lottery_dispatcher.GetTicketPrice() == init_price,
+        "Ticket price not set during initialization",
+    );
+
     let new_price: u256 = 750000000000000000;
     lottery_dispatcher.SetTicketPrice(new_price);
-    assert!(lottery_dispatcher.GetTicketPrice() == new_price, "Price not updated after initialization");
-    
+    assert!(
+        lottery_dispatcher.GetTicketPrice() == new_price, "Price not updated after initialization",
+    );
+
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
 }
 
@@ -190,16 +207,16 @@ fn test_ticket_price_with_initialize() {
 fn test_ticket_price_edge_cases() {
     let lottery_addr = deploy_lottery();
     let lottery_dispatcher = ILotteryDispatcher { contract_address: lottery_addr };
-    
+
     start_cheat_caller_address(lottery_dispatcher.contract_address, OWNER());
-    
+
     let min_price: u256 = 1;
     lottery_dispatcher.SetTicketPrice(min_price);
     assert!(lottery_dispatcher.GetTicketPrice() == min_price, "Minimum price not set correctly");
-    
+
     let max_price: u256 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     lottery_dispatcher.SetTicketPrice(max_price);
     assert!(lottery_dispatcher.GetTicketPrice() == max_price, "Maximum price not set correctly");
-    
+
     stop_cheat_caller_address(lottery_dispatcher.contract_address);
-} 
+}


### PR DESCRIPTION
This PR implements the multi-ticket purchase capability for the BuyTicket function, allowing users to purchase up to 10 tickets in a single transaction. This enhancement significantly improves user experience and gas efficiency while maintaining all security validations.

closes: #330 