### PR TITLE
 Feat/header play now 

### DIFF
--- a/packages/nextjs/components/landing-page/layout/hader.tsx
+++ b/packages/nextjs/components/landing-page/layout/hader.tsx
@@ -1,7 +1,9 @@
 "use client";
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Menu, X } from "lucide-react";
+import { Menu, X, ChevronRight } from "lucide-react";
+import { Button } from "../../ui/button";   
+import { useRouter } from "next/navigation";
 
 const navLinks = [
   { href: "#hero", label: "Home" },
@@ -16,6 +18,7 @@ const navLinks = [
 export default function Header() {
   const [scrolled, setScrolled] = useState(false);
   const [open, setOpen] = useState(false);
+  const navigation = useRouter();
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 40);
@@ -29,6 +32,11 @@ export default function Header() {
     document.querySelector(hash)?.scrollIntoView({ behavior: "smooth" });
   };
 
+  const goToDapp = () => {
+    setOpen(false);
+    navigation.push("/dapp");
+  };
+
   return (
     <>
       <header
@@ -39,24 +47,17 @@ export default function Header() {
         `}
       >
         <div className="container mx-auto relative flex h-20 items-center justify-center px-6 lg:px-8">
+          {/* Logo */}
           <button
             onClick={() => goTo("#hero")}
             className="absolute left-6 flex items-center space-x-2"
           >
-            <img
-              src="/Logo-sin-texto.png"
-              alt="Icono StarkLotto"
-              className="h-14 w-auto lg:h-16"
-            />
-
-            <img
-              src="/Logo_Sin_Texto_Transparente.png"
-              alt="StarkLotto Logo"
-              className="h-14 w-auto lg:h-16"
-            />
+            <img src="/Logo-sin-texto.png" alt="Icono StarkLotto" className="h-14 w-auto lg:h-16" />
+            <img src="/Logo_Sin_Texto_Transparente.png" alt="StarkLotto Logo" className="h-14 w-auto lg:h-16" />
           </button>
 
-          <nav className="hidden lg:flex lg:space-x-10">
+          {/* Desktop Nav */}
+          <nav className="hidden lg:flex lg:items-center lg:space-x-10">
             {navLinks.map(({ href, label }) => (
               <button
                 key={href}
@@ -64,16 +65,18 @@ export default function Header() {
                 className="relative px-2 py-1 text-sm font-medium text-white hover:text-starkYellow transition-colors duration-200"
               >
                 {label}
-                <span
-                  className="
-                    absolute left-0 bottom-0 h-0.5 w-full
-                    bg-starkYellow scale-x-0 origin-left
-                    transition-transform duration-300
-                    hover:scale-x-100
-                  "
-                />
+                <span className="absolute left-0 bottom-0 h-0.5 w-full bg-starkYellow scale-x-0 origin-left transition-transform duration-300 hover:scale-x-100" />
               </button>
             ))}
+
+            {/* Play Now Button - Desktop */}
+            <Button
+              size="lg"
+              className="px-6 py-3 text-base bg-starkYellow hover:bg-starkYellow-light text-black"
+              onClick={goToDapp}
+            >
+              Play now <ChevronRight className="ml-2 h-5 w-5 shrink-0" />
+            </Button>
           </nav>
 
           {/* Mobile Toggle */}
@@ -81,11 +84,7 @@ export default function Header() {
             onClick={() => setOpen(!open)}
             className="absolute right-6 p-2 rounded-md hover:bg-white/10 transition lg:hidden"
           >
-            {open ? (
-              <X className="h-6 w-6 text-white" />
-            ) : (
-              <Menu className="h-6 w-6 text-white" />
-            )}
+            {open ? <X className="h-6 w-6 text-white" /> : <Menu className="h-6 w-6 text-white" />}
           </button>
         </div>
       </header>
@@ -111,6 +110,17 @@ export default function Header() {
                   </button>
                 </li>
               ))}
+
+              {/* Play Now Button - Mobile */}
+              <li>
+                <Button
+                  size="lg"
+                  className="w-full px-8 py-6 text-lg bg-starkYellow hover:bg-starkYellow-light text-black flex justify-center"
+                  onClick={goToDapp}
+                >
+                  Play now <ChevronRight className="ml-2 h-5 w-5 shrink-0" />
+                </Button>
+              </li>
             </ul>
           </motion.nav>
         )}


### PR DESCRIPTION
## 📌 Description  
This PR adds the **“Play Now”** button to the **Header navigation** (desktop and mobile).  
The button now reuses the same **design system `<Button />`** from the Hero section, ensuring **visual consistency** and **single source of truth** for styling and behavior.

## 🎯 Motivation and Context  
Previously, the **CTA (Play Now)** was only visible inside the Hero section.  
This created friction because once the user scrolled down, the main action was no longer accessible.  

✨ With this change, **Play Now** is always visible in the header → improving **UX**, **conversion**, and **discoverability**.  

Closes #123

## 🛠️ How to Test the Change  
1. 🔹 Open the landing page.  
2. 🔹 Confirm the **“Play Now”** button appears in the **Header** (desktop).  
3. 🔹 On **mobile**, open the menu → button should be visible at the bottom of the navigation list.  
4. 🔹 Click on the button in both places → it should navigate to `/dapp` (same as Hero CTA).  
5. 🔹 Verify responsive design and hover/focus states.  

## 🖼️ Screenshots (Before / After)  
<img width="2559" height="1268" alt="image" src="https://github.com/user-attachments/assets/c623a799-a142-432d-bf52-f2a5412712ec" />


## 🔍 Type of Change  
- [ ] 🐞 **Bugfix**  
- [x] ✨ **New Feature**  
- [ ] 🚀 **Hotfix**  
- [ ] 🔄 **Refactoring**  
- [ ] 📖 **Documentation**  
- [ ] ❓ **Other**  

## ✅ Checklist Before Merging  
- [x] 🧪 I have tested the code and it works as expected.  
- [x] 🎨 My changes follow the project's coding style.  
- [x] 📖 Documentation updated if necessary.  
- [x] ⚠️ No new warnings or errors were introduced.  
- [x] 🔍 I have reviewed and approved my own code before submitting.  

## 📌 Additional Notes  
- Reused the **Hero Button component styles** for consistency.  
- Verified behavior on **desktop & mobile**.  
- Ensured **accessibility** (focusable, proper text contrast).  
