### PR TITLE
Refactor: Improve BuyTicket to accept an array of ticket number arrays

### DIFF
--- a/packages/snfoundry/contracts/tests/test_basic_functions.cairo
+++ b/packages/snfoundry/contracts/tests/test_basic_functions.cairo
@@ -1,4 +1,5 @@
 use contracts::Lottery::{ILotteryDispatcher, ILotteryDispatcherTrait};
+use core::array::ArrayTrait;
 use contracts::StarkPlayERC20::{IMintableDispatcher, IMintableDispatcherTrait};
 use openzeppelin_testing::declare_and_deploy;
 use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -69,6 +70,13 @@ fn create_valid_numbers() -> Array<u16> {
     array![1, 15, 25, 35, 40]
 }
 
+// Helper: wrap a single ticket numbers array into Array<Array<u16>>
+fn create_single_ticket_numbers_array(numbers: Array<u16>) -> Array<Array<u16>> {
+    let mut numbers_array = ArrayTrait::new();
+    numbers_array.append(numbers);
+    numbers_array
+}
+
 fn setup_mocks_for_buy_ticket(
     strk_play_address: ContractAddress,
     user: ContractAddress,
@@ -137,7 +145,8 @@ fn feign_buy_ticket(lottery: ILotteryDispatcher, buyer: ContractAddress) -> Arra
     let numbers = array![1, 2, 3, 4, 5];
     cheat_caller_address(lottery.contract_address, buyer, CheatSpan::Indefinite);
     cheat_block_timestamp(lottery.contract_address, 1, CheatSpan::TargetCalls(1));
-    lottery.BuyTicket(DEFAULT_ID, numbers.clone(), 1);
+    let numbers_array = create_single_ticket_numbers_array(numbers.clone());
+    lottery.BuyTicket(DEFAULT_ID, numbers_array, 1);
     numbers
 }
 
@@ -304,7 +313,8 @@ fn test_get_ticket_current_id_after_ticket_purchase() {
     let numbers = create_valid_numbers();
     start_cheat_caller_address(lottery.contract_address, USER1);
     cheat_block_timestamp(lottery.contract_address, 1, CheatSpan::TargetCalls(1));
-    lottery.BuyTicket(DEFAULT_ID, numbers, 1);
+    let numbers_array = create_single_ticket_numbers_array(numbers.clone());
+    lottery.BuyTicket(DEFAULT_ID, numbers_array, 1);
     stop_cheat_caller_address(lottery.contract_address);
 
     let current_id = lottery.GetTicketCurrentId();


### PR DESCRIPTION
## 📌 Description 
Refactor to align tests with the updated `BuyTicket` signature.
- Added helper `create_single_ticket_numbers_array` to wrap `Array<u16>` into `Array<Array<u16>>`.
- Updated calls to `BuyTicket` in `feign_buy_ticket` and `test_get_ticket_current_id_after_ticket_purchase` to use the new structure.

Files touched:
- `starklotto/packages/snfoundry/contracts/tests/test_basic_functions.cairo`

## 🎯 Motivation and Context 
The `Lottery.BuyTicket` function now expects an `Array<Array<u16>>` to support multiple tickets per call. Tests were passing a single `Array<u16>`, causing type errors. This change updates tests to the new API while preserving their original intent.

Closes # (link the corresponding issue if applicable)

## 🛠️ How to Test the Change (if applicable) 
1. Open WSL (per project convention) and navigate to the contracts package.
2. Run the tests for the modified file:
   - `scarb test -f test_get_ticket_current_id_after_ticket_purchase`
   - `scarb test -f test_basic_functions_integration`
3. Verify that no type errors occur and tests pass.

## 🖼️ Screenshots (if applicable) 

<img width="772" height="215" alt="image" src="https://github.com/user-attachments/assets/65bdf5e7-9067-4e0c-8b4e-f1dd0c39bae1" />


## 🔍 Type of Change
- [ ] 🐞 Bugfix
- [ ] ✨ New Feature
- [ ] 🚀 Hotfix
- [x] 🔄 Refactoring
- [ ] 📖 Documentation
- [ ] ❓ Other (please specify)

## ✅ Checklist Before Merging
- [x] 🧪 I have tested the code and it works as expected.
- [x] 🎨 My changes follow the project's coding style.
- [ ] 📖 I have updated the documentation if necessary.
- [x] ⚠️ No new warnings or errors were introduced.
- [x] 🔍 I have reviewed and approved my own code before submitting.

## 📌 Additional Notes 
- This change is backward-compatible for tests and aligns with the multi-ticket purchase API.