### PR TITLE
Update snfoundry.yml

### DIFF
--- a/.github/workflows/snfoundry.yml
+++ b/.github/workflows/snfoundry.yml
@@ -30,20 +30,20 @@ jobs:
         with:
           tool-versions: ./.tool-versions
 
-      - name: Compile contracts
-        run: scarb build
+      - name: Compile contracts (treat warnings as errors)
+        run: |
+          export RUSTFLAGS="-D warnings"
+          scarb build
         working-directory: ./packages/snfoundry/contracts
 
-      # Diagnóstico previo: lista todos los tests detectados
       - name: List tests
         run: snforge test -- --list
         working-directory: ./packages/snfoundry/contracts
 
-      # Ejecuta tests en modo verbose, imprime logs y stacktrace si algo falla.
-      # SNFORGE_FORMAT=pretty fuerza salida legible (no JSON), evitando parsers aguas abajo.
-      - name: Run snfoundry tests (verbose + logs)
+      - name: Run snfoundry tests (verbose + logs, warnings as errors)
         env:
           RUST_BACKTRACE: 1
           SNFORGE_FORMAT: pretty
+          RUSTFLAGS: "-D warnings"
         run: snforge test -- -v --print-logs
         working-directory: ./packages/snfoundry/contracts


### PR DESCRIPTION
## 📌 Description  
This PR updates the **Snfoundry Contracts CI** workflow to enforce stricter compilation rules.  
Warnings during compilation or tests will now be treated as errors, ensuring higher code quality and avoiding potential hidden issues.  

## 🎯 Motivation and Context  
Previously, the CI pipeline allowed builds/tests to pass even if warnings were present, which could lead to unnoticed technical debt or future bugs.  
By treating warnings as errors (`RUSTFLAGS="-D warnings"`), the pipeline enforces cleaner code and prevents merging code with compilation warnings.  

Closes # (add related issue number if applicable)  

## 🛠️ How to Test the Change (if applicable)  
1. 🔹 Push or open a PR that modifies code in `packages/snfoundry/contracts/**`.  
2. 🔹 Introduce a piece of code that would normally trigger a warning (e.g., unused variable).  
3. 🔹 Verify that the CI pipeline **fails** during the build or test stage.  
4. 🔹 Fix the warning and confirm that the pipeline **passes successfully**.  

## 🖼️ Screenshots (if applicable)  
*(Optional: Add screenshots of failed/passed workflow runs if you have them.)*  

## 🔍 Type of Change  
- [ ] 🐞 **Bugfix**  
- [x] ✨ **New Feature** – Stricter CI validation by treating warnings as errors.  
- [ ] 🚀 **Hotfix**  
- [ ] 🔄 **Refactoring**  
- [ ] 📖 **Documentation**  
- [ ] ❓ **Other**  

## ✅ Checklist Before Merging  
- [x] 🧪 I have tested the code and it works as expected.  
- [x] 🎨 My changes follow the project's coding style.  
- [ ] 📖 I have updated the documentation if necessary.  
- [x] ⚠️ No new warnings or errors were introduced.  
- [x] 🔍 I have reviewed and approved my own code before submitting.  

## 📌 Additional Notes  
- This update enforces a stricter pipeline that will prevent code with warnings from being merged.  
- Developers may need to address existing warnings in their code before their PRs can pass CI.  
