### PR TITLE
Feature/unify last draw results style

### DIFF
--- a/packages/nextjs/components/LastDrawResults.tsx
+++ b/packages/nextjs/components/LastDrawResults.tsx
@@ -104,17 +104,17 @@ export function LastDrawResults() {
   if (error && !drawResult) {
     return (
       <section aria-labelledby="last-draw-title" className="my-12">
-        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-950">
-          <div className="bg-gradient-to-r from-indigo-600 to-purple-600 px-6 py-6 text-white">
+        <div className="bg-[#1a2234] rounded-xl p-8">
+          <div className="flex items-center gap-2 mb-6">
+            <Trophy className="h-6 w-6 text-gray-300" />
             <h2
               id="last-draw-title"
-              className="flex items-center gap-2 text-2xl font-semibold tracking-tight md:text-3xl"
+              className="text-xl text-gray-300"
             >
-              <Trophy className="h-6 w-6" />
               {t("lastDraw.title")}
             </h2>
           </div>
-          <div className="p-6">
+          <div>
             <ErrorMessage
               error={error}
               onRetry={handleManualRefresh}
@@ -127,8 +127,8 @@ export function LastDrawResults() {
   }
 
   return (
-    <section aria-labelledby="last-draw-title" className="my-0">
-      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-950">
+    <section aria-labelledby="last-draw-title" className="my-12">
+      <div className="bg-[#1a2234] rounded-xl p-8">
         {/* New Draw Notification */}
         <AnimatePresence>
           {showNewDrawNotification && (
@@ -136,7 +136,7 @@ export function LastDrawResults() {
               initial={{ height: 0, opacity: 0 }}
               animate={{ height: "auto", opacity: 1 }}
               exit={{ height: 0, opacity: 0 }}
-              className="bg-green-500 px-6 py-3 text-white"
+              className="bg-green-500 px-6 py-3 text-white rounded-lg mb-6"
             >
               <div className="flex items-center gap-2">
                 <CheckCircle className="h-5 w-5" />
@@ -149,57 +149,55 @@ export function LastDrawResults() {
         </AnimatePresence>
 
         {/* Header */}
-        <div className="bg-gradient-to-r from-indigo-600 to-purple-600 px-6 py-6 text-white">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2
-                id="last-draw-title"
-                className="flex items-center gap-2 text-2xl font-semibold tracking-tight md:text-3xl"
-              >
-                <Trophy className="h-6 w-6" />
-                {t("lastDraw.title")}
-              </h2>
-              {drawResult && (
-                <p className="mt-1 text-sm text-white/90">
-                  {formatDrawDate(drawResult.drawDate)}
-                </p>
-              )}
-            </div>
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h2
+              id="last-draw-title"
+              className="flex items-center gap-2 text-xl text-gray-300"
+            >
+              <Trophy className="h-6 w-6" />
+              {t("lastDraw.title")}
+            </h2>
+            {drawResult && (
+              <p className="mt-1 text-sm text-gray-400">
+                {formatDrawDate(drawResult.drawDate)}
+              </p>
+            )}
+          </div>
 
-            {/* Status indicators */}
-            <div className="flex items-center gap-2">
-              {isRefreshing && (
+          {/* Status indicators */}
+          <div className="flex items-center gap-2">
+            {isRefreshing && (
+              <motion.div
+                animate={{ rotate: 360 }}
+                transition={{ duration: 1, repeat: Infinity, ease: "linear" }}
+                className="text-gray-400"
+              >
+                <RefreshCw className="h-5 w-5" />
+              </motion.div>
+            )}
+            {isPolling && !isRefreshing && (
+              <div className="flex items-center gap-1 text-gray-400">
                 <motion.div
-                  animate={{ rotate: 360 }}
-                  transition={{ duration: 1, repeat: Infinity, ease: "linear" }}
-                  className="text-white/80"
+                  animate={{ opacity: [0.5, 1, 0.5] }}
+                  transition={{ duration: 2, repeat: Infinity }}
                 >
-                  <RefreshCw className="h-5 w-5" />
+                  <Wifi className="h-5 w-5" />
                 </motion.div>
-              )}
-              {isPolling && !isRefreshing && (
-                <div className="flex items-center gap-1 text-white/80">
-                  <motion.div
-                    animate={{ opacity: [0.5, 1, 0.5] }}
-                    transition={{ duration: 2, repeat: Infinity }}
-                  >
-                    <Wifi className="h-5 w-5" />
-                  </motion.div>
-                  <span className="text-xs">{t("status.live")}</span>
-                </div>
-              )}
-              {lastFetch && (
-                <div className="text-xs text-white/60">
-                  {t("status.updated")}{" "}
-                  {new Date(lastFetch).toLocaleTimeString()}
-                </div>
-              )}
-            </div>
+                <span className="text-xs">{t("status.live")}</span>
+              </div>
+            )}
+            {lastFetch && (
+              <div className="text-xs text-gray-500">
+                {t("status.updated")}{" "}
+                {new Date(lastFetch).toLocaleTimeString()}
+              </div>
+            )}
           </div>
         </div>
 
         {/* Content */}
-        <div className="p-6">
+        <div>
           {isLoading ? (
             <DrawResultsSkeleton />
           ) : drawResult ? (
@@ -210,8 +208,16 @@ export function LastDrawResults() {
               transition={{ duration: 0.5 }}
               className="space-y-6"
             >
+              {/* Jackpot Amount - matching Next Draw style */}
+              <div>
+                <p className="text-[#4ade80] text-4xl font-bold mb-6">
+                  {formatCurrency(drawResult.jackpotAmount)}
+                </p>
+              </div>
+
+              {/* Winning Numbers */}
               <div className="space-y-3">
-                <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                <h3 className="text-sm font-medium text-gray-400">
                   {t("lastDraw.winningNumbers")}
                 </h3>
                 <div className="flex flex-wrap gap-2 justify-center sm:justify-start">
@@ -229,18 +235,19 @@ export function LastDrawResults() {
                 </div>
               </div>
 
+              {/* Results Info */}
               <div className="grid grid-cols-1 gap-4 pt-2 md:grid-cols-2">
                 <motion.div
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: 0.3 }}
-                  className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900"
+                  className="rounded-lg bg-[#232b3b] p-4"
                 >
-                  <h3 className="mb-1 text-sm font-medium text-gray-500 dark:text-gray-400">
-                    {t("lastDraw.jackpotAmount")}
+                  <h3 className="mb-1 text-sm font-medium text-gray-400">
+                    {t("lastDraw.results")}
                   </h3>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                    {formatCurrency(drawResult.jackpotAmount)}
+                  <p className="text-2xl font-bold text-white">
+                    {`${drawResult.winnerCount} ${drawResult.winnerCount === 1 ? t("lastDraw.winner") : t("lastDraw.winners")}`}
                   </p>
                 </motion.div>
 
@@ -248,30 +255,30 @@ export function LastDrawResults() {
                   initial={{ opacity: 0, x: 20 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: 0.4 }}
-                  className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900"
+                  className="rounded-lg bg-[#232b3b] p-4"
                 >
-                  <h3 className="mb-1 text-sm font-medium text-gray-500 dark:text-gray-400">
-                    {t("lastDraw.results")}
+                  <h3 className="mb-1 text-sm font-medium text-gray-400">
+                    Draw Status
                   </h3>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                    {`${drawResult.winnerCount} ${drawResult.winnerCount === 1 ? t("lastDraw.winner") : t("lastDraw.winners")}`}
+                  <p className="text-2xl font-bold text-white">
+                    {drawResult.status}
                   </p>
                 </motion.div>
               </div>
 
               {/* Draw Status */}
               <div className="pt-2">
-                <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                <div className="flex items-center gap-2 text-sm text-gray-400">
                   <Clock className="h-4 w-4" />
                   <span>
-                    Draw #{drawResult.drawNumber} • Status: {drawResult.status}
+                    Draw #{drawResult.drawNumber}
                   </span>
                 </div>
               </div>
             </motion.div>
           ) : (
             <div className="text-center py-8">
-              <p className="text-gray-500 dark:text-gray-400">
+              <p className="text-gray-400">
                 {t("status.noResults")}
               </p>
             </div>
@@ -282,14 +289,14 @@ export function LastDrawResults() {
             <motion.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
-              className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg dark:bg-yellow-950 dark:border-yellow-800"
+              className="mt-4 p-3 bg-yellow-500/20 border border-yellow-500/30 rounded-lg"
             >
-              <div className="flex items-center gap-2 text-sm text-yellow-800 dark:text-yellow-200">
+              <div className="flex items-center gap-2 text-sm text-yellow-300">
                 <AlertCircle className="h-4 w-4" />
                 <span>{t("notifications.unableToFetch")}</span>
                 <button
                   onClick={handleManualRefresh}
-                  className="ml-auto text-yellow-600 hover:text-yellow-500 dark:text-yellow-400"
+                  className="ml-auto text-yellow-400 hover:text-yellow-300"
                 >
                   <RefreshCw className="h-4 w-4" />
                 </button>
@@ -299,10 +306,10 @@ export function LastDrawResults() {
         </div>
 
         {/* Footer */}
-        <div className="flex justify-between items-center border-t border-gray-200 bg-gray-50/30 px-6 py-4 dark:border-gray-800 dark:bg-gray-900/30">
+        <div className="flex justify-between items-center mt-8 pt-6 border-t border-gray-600">
           <button
             onClick={() => router.push("/results")}
-            className="inline-flex items-center text-sm font-medium text-indigo-600 transition-colors hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+            className="inline-flex items-center text-sm font-medium text-gray-300 transition-colors hover:text-white"
           >
             {t("lastDraw.viewPrevious")}
             <ChevronRight className="ml-1 h-4 w-4" />
@@ -315,7 +322,7 @@ export function LastDrawResults() {
               whileTap={{ scale: 0.95 }}
               onClick={handleManualRefresh}
               disabled={isLoading || isRefreshing}
-              className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700"
+              className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-gray-400 bg-[#232b3b] hover:bg-[#2a3441] rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <RefreshCw
                 className={`h-3 w-3 ${isRefreshing ? "animate-spin" : ""}`}
@@ -328,8 +335,8 @@ export function LastDrawResults() {
               onClick={isPolling ? stopPolling : startPolling}
               className={`inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
                 isPolling
-                  ? "text-green-700 bg-green-100 hover:bg-green-200 dark:text-green-400 dark:bg-green-900 dark:hover:bg-green-800"
-                  : "text-gray-600 bg-gray-100 hover:bg-gray-200 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700"
+                  ? "text-green-400 bg-green-500/20 hover:bg-green-500/30"
+                  : "text-gray-400 bg-[#232b3b] hover:bg-[#2a3441]"
               }`}
             >
               <div


### PR DESCRIPTION
## 🎯 Issue
Resolves ISSUE-FE-003: Unify Last Draw Results Style with Next Draw
Closes #485 

## 📝 Description
Modified the "Last Draw Results" component to have the same visual style and structure as the "Next Draw" component on the dapp's initial page, creating a unified and coherent user experience.

## 🔧 Changes Made

### Visual Consistency
- ✅ Applied same background color (`bg-[#1a2234]`) as Next Draw
- ✅ Updated padding system to `p-8` (matching Next Draw)
- ✅ Applied consistent border radius (`rounded-xl`)
- ✅ Unified color scheme (gray-300, gray-400, green accent `#4ade80`)

### Layout Structure
- ✅ Simplified header structure to match Next Draw's clean layout
- ✅ Prominently displayed jackpot amount with green accent color
- ✅ Updated info cards to use secondary background (`bg-[#232b3b]`)
- ✅ Maintained responsive design and accessibility

### Functionality Preserved
- ✅ All event handlers and state management intact
- ✅ All hooks and interactive features preserved
- ✅ All animations and transitions maintained
- ✅ Error handling and loading states updated with new styling

## 🧪 Testing
- [x] Visual consistency verified between Next Draw and Last Draw Results
- [x] All functionality tested (refresh, polling, navigation)
- [x] Responsive design verified on different screen sizes
- [x] Accessibility features preserved
- [x] No linting errors introduced

## 📸 Screenshots
**Before**

<img width="1087" height="509" alt="Screenshot 2025-09-19 at 10 30 10 AM" src="https://github.com/user-attachments/assets/fb580c0c-b471-43c8-8d0a-53c319e804e2" />


**After**

<img width="1440" height="900" alt="Screenshot 2025-09-19 at 10 27 15 AM" src="https://github.com/user-attachments/assets/eb3fea2b-c497-45fe-a09c-402e90e7e8df" />

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] All existing functionality preserved
- [x] Responsive design maintained
- [x] Accessibility features preserved
- [x] No breaking changes introduced
